### PR TITLE
Fix missing 'error'    => true, in readme for LosLog middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ return [
             'middleware' => [
                 LosMiddleware\LosLog\LosLog::class,
             ],
+            'error'    => true,
             'priority' => -10000,
         ],
     ],


### PR DESCRIPTION
related with this fix: https://github.com/zendframework/zend-expressive-skeleton/pull/66
